### PR TITLE
Fix holdem CPU test broken by tile distribution change

### DIFF
--- a/backend/holdem.go
+++ b/backend/holdem.go
@@ -58,7 +58,7 @@ type Tile struct {
 	Blank  bool   `json:"blank"`
 }
 
-// Standard Scrabble distribution, minus blanks (98 tiles).
+// Custom letter distribution, minus blanks (99 tiles).
 type letterSpec struct {
 	letter string
 	points int

--- a/backend/holdem_cpu_test.go
+++ b/backend/holdem_cpu_test.go
@@ -24,13 +24,15 @@ func TestBestScoreOnlyMatchesSolver(t *testing.T) {
 	}
 }
 
-// remainingTiles must exclude exactly the seen tiles and total 98 - len(seen).
+// remainingTiles must exclude exactly the seen tiles, leaving the rest of the
+// bag. We derive the expected count from the bag itself so the test tracks the
+// letter distribution rather than a hardcoded total.
 func TestRemainingTiles(t *testing.T) {
 	bag := newBag()
 	seen := bag[:10]
 	rem := remainingTiles(seen)
-	if len(rem) != 98-len(seen) {
-		t.Fatalf("remaining count = %d, want %d", len(rem), 98-len(seen))
+	if len(rem) != len(bag)-len(seen) {
+		t.Fatalf("remaining count = %d, want %d", len(rem), len(bag)-len(seen))
 	}
 }
 


### PR DESCRIPTION
The bag grew from 98 to 99 tiles when the point-value change bumped K's
count from 1 to 2. TestRemainingTiles hardcoded 98, so it failed. Derive
the expected count from the bag itself so the test tracks the letter
distribution instead of a fixed total, and update the stale comment.

https://claude.ai/code/session_012tb314yse7RzoucZhqHfeC