### PR TITLE
Make navbar scroll away instead of sticking to top

### DIFF
--- a/header.css
+++ b/header.css
@@ -1,7 +1,6 @@
-/* Header — sticky, semi-transparent, syncs with the warm-neutral palette */
+/* Header — scrolls away with the page, semi-transparent, syncs with the warm-neutral palette */
 header.site-header {
-    position: sticky;
-    top: 0;
+    position: static;
     z-index: 50;
     height: var(--header-height, 64px);
     background-color: var(--bgColor-default);


### PR DESCRIPTION
Change site-header from position: sticky to position: static so it no
longer pins to the top of the viewport on scroll. Frees up screen real
estate, especially on mobile.